### PR TITLE
Fix create validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+## [0.2.1] - 2022-11-14
+### Fixed
+- fixed `Create` assets validation according to transactions spec `v3.0`
 ## [0.2.0] - 2022-10-27
 ### Changed
 - update transaction version number from `v2.0` to `v3.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2022-11-14
 ### Fixed
 - fixed `Create` assets validation according to transactions spec `v3.0`
+
+### Removed
+- removed unused code dependent on a `localmongodb` backend
+
 ## [0.2.0] - 2022-10-27
 ### Changed
 - update transaction version number from `v2.0` to `v3.0`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "planetmint-transactions"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python implementation of the planetmint transactions spec"
 authors = ["Lorenz Herzberger <lorenzherzberger@gmail.com>"]
 readme = "README.md"

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -280,9 +280,11 @@ def test_transaction_serialization(user_input, user_output, data):
         "outputs": [user_output.to_dict()],
         "operation": Transaction.CREATE,
         "metadata": None,
-        "assets": [{
-            "data": data,
-        }],
+        "assets": [
+            {
+                "data": data,
+            }
+        ],
     }
 
     tx = Transaction(Transaction.CREATE, [{"data": data}], [user_input], [user_output])
@@ -568,9 +570,11 @@ def test_create_create_transaction_single_io(user_output, user_pub, data):
     expected = {
         "outputs": [user_output.to_dict()],
         "metadata": data,
-        "assets": [{
-            "data": data,
-        }],
+        "assets": [
+            {
+                "data": data,
+            }
+        ],
         "inputs": [{"owners_before": [user_pub], "fulfillment": None, "fulfills": None}],
         "operation": "CREATE",
         "version": Transaction.VERSION,
@@ -623,7 +627,7 @@ def test_validate_multiple_io_create_transaction(user_pub, user_priv, user2_pub,
         [user_pub, user2_pub],
         [([user_pub], 1), ([user2_pub], 1)],
         metadata="QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4",
-        assets=asset_definition
+        assets=asset_definition,
     )
     tx = tx.sign([user_priv, user2_priv])
     assert tx.inputs_valid() is True
@@ -637,9 +641,11 @@ def test_create_create_transaction_threshold(
     expected = {
         "outputs": [user_user2_threshold_output.to_dict()],
         "metadata": data,
-        "assets": [{
-            "data": data,
-        }],
+        "assets": [
+            {
+                "data": data,
+            }
+        ],
         "inputs": [
             {
                 "owners_before": [
@@ -706,9 +712,11 @@ def test_create_transfer_transaction_single_io(tx, user_pub, user2_pub, user2_ou
         "id": None,
         "outputs": [user2_output.to_dict()],
         "metadata": None,
-        "assets": [{
-            "id": tx.id,
-        }],
+        "assets": [
+            {
+                "id": tx.id,
+            }
+        ],
         "inputs": [
             {
                 "owners_before": [user_pub],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,6 +313,7 @@ def tri_state_transaction(request):
     tx["inputs"][0]["fulfillment"] = request.param["fulfillment"]
     return tx
 
+
 @pytest.fixture
 def user_sk():
     return USER_PRIVATE_KEY
@@ -322,17 +323,20 @@ def user_sk():
 def user_pk():
     return USER_PUBLIC_KEY
 
+
 @pytest.fixture
 def alice():
     from transactions.common.crypto import generate_key_pair
 
     return generate_key_pair()
 
+
 @pytest.fixture
 def bob():
     from transactions.common.crypto import generate_key_pair
 
     return generate_key_pair()
+
 
 @pytest.fixture
 def carol():
@@ -347,6 +351,7 @@ def merlin():
 
     return generate_key_pair()
 
+
 @pytest.fixture
 def create_tx(alice, user_pk):
     name = f"I am created by the create_tx fixture. My random identifier is {random.random()}."
@@ -357,6 +362,7 @@ def create_tx(alice, user_pk):
 @pytest.fixture
 def signed_create_tx(alice, create_tx):
     return create_tx.sign([alice.private_key])
+
 
 @pytest.fixture
 def signed_transfer_tx(signed_create_tx, user_pk, user_sk):

--- a/transactions/common/memoize.py
+++ b/transactions/common/memoize.py
@@ -3,6 +3,7 @@ import codecs
 from functools import lru_cache
 from typing import Callable
 
+
 class HDict(dict):
     def __hash__(self):
         return hash(codecs.decode(self["id"], "hex"))

--- a/transactions/common/output.py
+++ b/transactions/common/output.py
@@ -137,7 +137,9 @@ class Output(object):
             return cls(threshold_cond, public_keys, amount=amount)
 
     @classmethod
-    def _gen_condition(cls, initial: type[ThresholdSha256], new_public_keys: Union[list[str],str]) -> type[ThresholdSha256]:
+    def _gen_condition(
+        cls, initial: type[ThresholdSha256], new_public_keys: Union[list[str], str]
+    ) -> type[ThresholdSha256]:
         """Generates ThresholdSha256 conditions from a list of new owners.
 
         Note:

--- a/transactions/common/transaction.py
+++ b/transactions/common/transaction.py
@@ -31,7 +31,7 @@ from transactions.common.exceptions import (
     AssetIdMismatch,
 )
 from transactions.common.schema import validate_transaction_schema
-from transactions.common.utils import serialize, validate_key
+from transactions.common.utils import serialize
 from .memoize import memoize_from_dict, memoize_to_dict
 from .input import Input
 from .output import Output
@@ -783,8 +783,6 @@ class Transaction(object):
     @classmethod
     def validate_schema(cls, tx):
         validate_transaction_schema(tx)
-        validate_txn_obj(cls.ASSETS, tx[cls.ASSETS], cls.DATA, validate_key)
-        validate_txn_obj(cls.METADATA, tx, cls.METADATA, validate_key)
 
     @classmethod
     def complete_tx_i_o(self, tx_signers, recipients):

--- a/transactions/common/transaction.py
+++ b/transactions/common/transaction.py
@@ -31,7 +31,7 @@ from transactions.common.exceptions import (
     AssetIdMismatch,
 )
 from transactions.common.schema import validate_transaction_schema
-from transactions.common.utils import serialize, validate_txn_obj, validate_key, validate_language_key
+from transactions.common.utils import serialize, validate_key
 from .memoize import memoize_from_dict, memoize_to_dict
 from .input import Input
 from .output import Output
@@ -175,7 +175,6 @@ class Transaction(object):
         self.script = script
         self._id = hash_id
         self.tx_dict = tx_dict
-
 
     @property
     def unspent_outputs(self):
@@ -520,7 +519,9 @@ class Transaction(object):
         return all(validate(i, cond) for i, cond in enumerate(output_condition_uris))
 
     @lru_cache(maxsize=16384)
-    def _input_valid(self, input_: Input, operation: str, message: str, output_condition_uri: Optional[str] = None) -> bool:
+    def _input_valid(
+        self, input_: Input, operation: str, message: str, output_condition_uri: Optional[str] = None
+    ) -> bool:
         """Validates a single Input against a single Output.
 
         Note:
@@ -784,8 +785,6 @@ class Transaction(object):
         validate_transaction_schema(tx)
         validate_txn_obj(cls.ASSETS, tx[cls.ASSETS], cls.DATA, validate_key)
         validate_txn_obj(cls.METADATA, tx, cls.METADATA, validate_key)
-        validate_language_key(tx[cls.ASSETS], cls.DATA)
-        validate_language_key(tx, cls.METADATA)
 
     @classmethod
     def complete_tx_i_o(self, tx_signers, recipients):

--- a/transactions/common/transaction_link.py
+++ b/transactions/common/transaction_link.py
@@ -59,7 +59,7 @@ class TransactionLink(object):
         except TypeError:
             return cls()
 
-    def to_dict(self) -> Union[dict,None]:
+    def to_dict(self) -> Union[dict, None]:
         """Transforms the object to a Python dictionary.
 
         Returns:
@@ -73,7 +73,7 @@ class TransactionLink(object):
                 "output_index": self.output,
             }
 
-    def to_uri(self, path: str = "") -> Union[str,None]:
+    def to_uri(self, path: str = "") -> Union[str, None]:
         if self.txid is None and self.output is None:
             return None
         return "{}/transactions/{}/outputs/{}".format(path, self.txid, self.output)

--- a/transactions/common/utils.py
+++ b/transactions/common/utils.py
@@ -50,6 +50,7 @@ VALID_LANGUAGES = (
     "tr",
 )
 
+
 def gen_timestamp() -> str:
     """The Unix time, rounded to the nearest second.
     See https://en.wikipedia.org/wiki/Unix_time
@@ -92,32 +93,6 @@ def deserialize(data: str) -> dict:
         string.
     """
     return rapidjson.loads(data)
-
-
-def validate_txn_obj(obj_name: str, obj: dict, key: str, validation_fun: Callable) -> None:
-    """Validate value of `key` in `obj` using `validation_fun`.
-
-    Args:
-        obj_name (str): name for `obj` being validated.
-        obj (dict): dictionary object.
-        key (str): key to be validated in `obj`.
-        validation_fun (function): function used to validate the value
-        of `key`.
-
-    Returns:
-        None: indicates validation successful
-
-    Raises:
-        ValidationError: `validation_fun` will raise exception on failure
-    """
-    backend = "tarantool" # Config().get()["database"]["backend"]
-
-    if backend == "localmongodb":
-        data = obj.get(key, {})
-        if isinstance(data, dict):
-            validate_all_keys_in_obj(obj_name, data, validation_fun)
-        elif isinstance(data, list):
-            validate_all_items_in_list(obj_name, data, validation_fun)
 
 
 def validate_all_items_in_list(obj_name: str, data: list, validation_fun: Callable) -> None:
@@ -265,27 +240,6 @@ def _fulfillment_from_details(data: dict, _depth: int = 0):
 
     raise UnsupportedTypeError(data.get("type"))
 
-def validate_language_key(obj, key):
-    """Validate all nested "language" key in `obj`.
-
-    Args:
-        obj (dict): dictionary whose "language" key is to be validated.
-
-    Returns:
-        None: validation successful
-
-     Raises:
-         ValidationError: will raise exception in case language is not valid.
-    """
-    backend = "tarantool" # Config().get()["database"]["backend"]
-
-    if backend == "localmongodb":
-        data = obj.get(key, {})
-        if isinstance(data, dict):
-            validate_all_values_for_key_in_obj(data, "language", validate_language)
-        elif isinstance(data, list):
-            validate_all_values_for_key_in_list(data, "language", validate_language)
-
 
 def validate_language(value):
     """Check if `value` is a valid language.
@@ -308,6 +262,7 @@ def validate_language(value):
             'something else like "lang".'
         ).format(value)
         raise ValidationError(error_str)
+
 
 def key_from_base64(base64_key):
     return base64.b64decode(base64_key).hex().upper()

--- a/transactions/types/assets/create.py
+++ b/transactions/types/assets/create.py
@@ -34,7 +34,7 @@ class Create(Transaction):
             if not isinstance(assets, list) and len(assets) != 1:
                 raise TypeError("`assets` must be a list of length 1 or None")
             if "data" in assets[0]:
-                if not is_cid(assets[0]["data"]) and assets[0]["data"] is not None:
+                if assets[0]["data"] is not None and not is_cid(assets[0]["data"]):
                     raise TypeError("`asset.data` must be a CID string or None")
         if not (metadata is None or is_cid(metadata)):
             raise TypeError("`metadata` must be a CID string or None")

--- a/transactions/types/assets/create.py
+++ b/transactions/types/assets/create.py
@@ -15,7 +15,13 @@ class Create(Transaction):
     ALLOWED_OPERATIONS = (OPERATION,)
 
     @classmethod
-    def validate_create(self, tx_signers: list[str], recipients: list[tuple[list[str],int]], assets: Optional[list[dict]], metadata: Optional[dict]):
+    def validate_create(
+        self,
+        tx_signers: list[str],
+        recipients: list[tuple[list[str], int]],
+        assets: Optional[list[dict]],
+        metadata: Optional[dict],
+    ):
         if not isinstance(tx_signers, list):
             raise TypeError("`tx_signers` must be a list instance")
         if not isinstance(recipients, list):
@@ -27,15 +33,22 @@ class Create(Transaction):
         if not assets is None:
             if not isinstance(assets, list) and len(assets) != 1:
                 raise TypeError("`assets` must be a list of length 1 or None")
-            if "data" in assets[0] and not is_cid(assets[0]["data"]):
-                raise TypeError("`asset.data` must be a CID string")
+            if "data" in assets[0]:
+                if not is_cid(assets[0]["data"]) and assets[0]["data"] is not None:
+                    raise TypeError("`asset.data` must be a CID string or None")
         if not (metadata is None or is_cid(metadata)):
             raise TypeError("`metadata` must be a CID string or None")
 
         return True
 
     @classmethod
-    def generate(cls, tx_signers: list[str], recipients: list[tuple[list[str],int]], metadata: Optional[dict] = None, assets: Optional[list] = None):
+    def generate(
+        cls,
+        tx_signers: list[str],
+        recipients: list[tuple[list[str], int]],
+        metadata: Optional[dict] = None,
+        assets: Optional[list] = [{"data": None}],
+    ):
         """A simple way to generate a `CREATE` transaction.
 
         Note:

--- a/transactions/types/assets/transfer.py
+++ b/transactions/types/assets/transfer.py
@@ -17,7 +17,13 @@ class Transfer(Transaction):
     ALLOWED_OPERATIONS = (OPERATION,)
 
     @classmethod
-    def validate_transfer(cls, inputs: list[Input], recipients: list[tuple[list[str],int]], asset_ids: list[str], metadata: Optional[dict]):
+    def validate_transfer(
+        cls,
+        inputs: list[Input],
+        recipients: list[tuple[list[str], int]],
+        asset_ids: list[str],
+        metadata: Optional[dict],
+    ):
         if not isinstance(inputs, list):
             raise TypeError("`inputs` must be a list instance")
         if len(inputs) == 0:
@@ -42,7 +48,13 @@ class Transfer(Transaction):
         return (deepcopy(inputs), outputs)
 
     @classmethod
-    def generate(cls, inputs: list[Input], recipients: list[tuple[list[str],int]], asset_ids: list[str], metadata: Optional[dict] = None):
+    def generate(
+        cls,
+        inputs: list[Input],
+        recipients: list[tuple[list[str], int]],
+        asset_ids: list[str],
+        metadata: Optional[dict] = None,
+    ):
         """A simple way to generate a `TRANSFER` transaction.
 
         Note:

--- a/transactions/types/elections/election.py
+++ b/transactions/types/elections/election.py
@@ -9,6 +9,7 @@ from typing import Optional
 from transactions.common.transaction import Transaction
 from transactions.common.schema import _validate_schema, TX_SCHEMA_COMMON
 
+
 class Election(Transaction):
     """Represents election transactions.
 

--- a/transactions/types/elections/vote.py
+++ b/transactions/types/elections/vote.py
@@ -25,7 +25,7 @@ class Vote(Transfer):
     @classmethod
     def generate(cls, inputs, recipients, election_ids, metadata=None):
         (inputs, outputs) = cls.validate_transfer(inputs, recipients, election_ids, metadata)
-        election_vote = cls(cls.OPERATION, [{"id": id} for  id in election_ids], inputs, outputs, metadata)
+        election_vote = cls(cls.OPERATION, [{"id": id} for id in election_ids], inputs, outputs, metadata)
         cls.validate_schema(election_vote.to_dict())
         return election_vote
 


### PR DESCRIPTION
## Description
- adjusted `CREATE` transfer validation to allow for `assets = [{"data": None}]` according to spec `v3.0`
- removed unused `localmongodb` dependent code
- blacked code