### PR TITLE
Upgrade to a new package name of planetmint cryptoconditions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+# Copyright © 2020 Interplanetary Database Association e.V.,
+# Planetmint and IPDB software contributors.
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
+name: Lint
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          options: "--check -l 119"
+          src: "."

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,36 @@
+
+name: Deploy packages
+on: 
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Setup poetry
+        uses: Gr1N/setup-poetry@v7
+
+      - name: Install dependencies
+        run: poetry install --with dev 
+
+      - name: Test build
+        run: poetry build && poetry run twine check dist/*
+
+      - name: Upload to TestPyPI
+        run: |
+          poetry build
+          poetry run twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,32 @@
+# Copyright © 2020 Interplanetary Database Association e.V.,
+# Planetmint and IPDB software contributors.
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
+name: Unit tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      
+      - name: Setup poetry
+        uses: Gr1N/setup-poetry@v7
+
+      - name: Install dependencies
+        run: poetry install --with test
+
+      - name: Run tests
+        run: poetry run pytest -v 
+
+
+      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+
+## [0.2.2] - 2022-11-28
+### Fixed
+- fixed: upgraded to planetmint-cryptoconditions version 1.0.0
+
 ## [0.2.1] - 2022-11-14
 ### Fixed
 - fixed `Create` assets validation according to transactions spec `v3.0`

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,7 +35,7 @@ python-versions = "*"
 name = "cffi"
 version = "1.15.1"
 description = "Foreign Function Interface for Python calling C code."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -52,9 +52,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "cryptography"
-version = "38.0.1"
+version = "3.4.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -62,12 +62,12 @@ python-versions = ">=3.6"
 cffi = ">=1.12"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx_rtd_theme"]
+docstest = ["doc8", "pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
+test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
 
 [[package]]
 name = "exceptiongroup"
@@ -162,16 +162,18 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "planetmint-cryptoconditions"
-version = "0.10.0"
+version = "1.0.0"
 description = "Multi-algorithm, multi-level, multi-signature format for expressing conditions and fulfillments according to the Interledger Protocol (ILP)."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.9,<4.0"
 
-[package.extras]
-dev = ["PyNaCl (==1.4.0)", "Sphinx (>=1.3.5)", "base58 (>=2.1.0)", "coverage", "cryptography (==3.4.7)", "hypothesis", "ipdb", "ipython", "pep8", "pyasn1 (==0.4.8)", "pyflakes", "pylint", "pytest", "pytest-cov", "pytest-xdist", "recommonmark (>=0.4.0)", "sphinx-press-theme (==0.8.0)", "sphinxcontrib-napoleon (>=0.4.4)", "twine", "zenroom (==2.1.0.dev1655293214)"]
-docs = ["Sphinx (>=1.3.5)", "recommonmark (>=0.4.0)", "sphinx-press-theme (==0.8.0)", "sphinxcontrib-napoleon (>=0.4.4)"]
-test = ["PyNaCl (==1.4.0)", "base58 (>=2.1.0)", "coverage", "cryptography (==3.4.7)", "hypothesis", "pep8", "pyasn1 (==0.4.8)", "pyflakes", "pylint", "pytest", "pytest-cov", "pytest-xdist", "twine", "zenroom (==2.1.0.dev1655293214)"]
+[package.dependencies]
+base58 = "2.1.1"
+cryptography = "3.4.7"
+pyasn1 = "0.4.8"
+PyNaCl = "1.4.0"
+zenroom = ">=2.3.1,<3.0.0"
 
 [[package]]
 name = "planetmint-ipld"
@@ -297,7 +299,7 @@ varint = ">=1.0.2,<2.0.0"
 name = "pyasn1"
 version = "0.4.8"
 description = "ASN.1 types and codecs"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -305,20 +307,21 @@ python-versions = "*"
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "PyNaCl"
-version = "1.5.0"
+version = "1.4.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
-category = "dev"
+category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
 cffi = ">=1.4.1"
+six = "*"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx_rtd_theme"]
@@ -421,11 +424,11 @@ python-versions = "*"
 
 [[package]]
 name = "zenroom"
-version = "2.1.0.dev1655293214"
+version = "2.4.2"
 description = "Zenroom for Python: Bindings of Zenroom library for Python."
-category = "dev"
+category = "main"
 optional = false
-python-versions = ">=3.6, <4"
+python-versions = ">=3.8, <4"
 
 [package.extras]
 test = ["pytest", "schema"]
@@ -433,7 +436,7 @@ test = ["pytest", "schema"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "cc0740ee6b02613addb168cc76ebba1423ebbd0318d19ec595c90f141285e2f4"
+content-hash = "698af526245abd9e2d8c57310af2a7d5780613c516e96f0e9af26dca2afd8f43"
 
 [metadata.files]
 attrs = [
@@ -518,32 +521,20 @@ colorama = [
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 cryptography = [
-    {file = "cryptography-38.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f"},
-    {file = "cryptography-38.0.1-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad"},
-    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:3b72c360427889b40f36dc214630e688c2fe03e16c162ef0aa41da7ab1455153"},
-    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:194044c6b89a2f9f169df475cc167f6157eb9151cc69af8a2a163481d45cc407"},
-    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e"},
-    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:16fa61e7481f4b77ef53991075de29fc5bacb582a1244046d2e8b4bb72ef66d0"},
-    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d4ef6cc305394ed669d4d9eebf10d3a101059bdcf2669c366ec1d14e4fb227bd"},
-    {file = "cryptography-38.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3261725c0ef84e7592597606f6583385fed2a5ec3909f43bc475ade9729a41d6"},
-    {file = "cryptography-38.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:0297ffc478bdd237f5ca3a7dc96fc0d315670bfa099c04dc3a4a2172008a405a"},
-    {file = "cryptography-38.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:89ed49784ba88c221756ff4d4755dbc03b3c8d2c5103f6d6b4f83a0fb1e85294"},
-    {file = "cryptography-38.0.1-cp36-abi3-win32.whl", hash = "sha256:ac7e48f7e7261207d750fa7e55eac2d45f720027d5703cd9007e9b37bbb59ac0"},
-    {file = "cryptography-38.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:ad7353f6ddf285aeadfaf79e5a6829110106ff8189391704c1d8801aa0bae45a"},
-    {file = "cryptography-38.0.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:896dd3a66959d3a5ddcfc140a53391f69ff1e8f25d93f0e2e7830c6de90ceb9d"},
-    {file = "cryptography-38.0.1-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d3971e2749a723e9084dd507584e2a2761f78ad2c638aa31e80bc7a15c9db4f9"},
-    {file = "cryptography-38.0.1-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:79473cf8a5cbc471979bd9378c9f425384980fcf2ab6534b18ed7d0d9843987d"},
-    {file = "cryptography-38.0.1-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:d9e69ae01f99abe6ad646947bba8941e896cb3aa805be2597a0400e0764b5818"},
-    {file = "cryptography-38.0.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5067ee7f2bce36b11d0e334abcd1ccf8c541fc0bbdaf57cdd511fdee53e879b6"},
-    {file = "cryptography-38.0.1-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:3e3a2599e640927089f932295a9a247fc40a5bdf69b0484532f530471a382750"},
-    {file = "cryptography-38.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c2e5856248a416767322c8668ef1845ad46ee62629266f84a8f007a317141013"},
-    {file = "cryptography-38.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:64760ba5331e3f1794d0bcaabc0d0c39e8c60bf67d09c93dc0e54189dfd7cfe5"},
-    {file = "cryptography-38.0.1-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b6c9b706316d7b5a137c35e14f4103e2115b088c412140fdbd5f87c73284df61"},
-    {file = "cryptography-38.0.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0163a849b6f315bf52815e238bc2b2346604413fa7c1601eea84bcddb5fb9ac"},
-    {file = "cryptography-38.0.1-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d1a5bd52d684e49a36582193e0b89ff267704cd4025abefb9e26803adeb3e5fb"},
-    {file = "cryptography-38.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:765fa194a0f3372d83005ab83ab35d7c5526c4e22951e46059b8ac678b44fa5a"},
-    {file = "cryptography-38.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b"},
-    {file = "cryptography-38.0.1.tar.gz", hash = "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7"},
+    {file = "cryptography-3.4.7-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1"},
+    {file = "cryptography-3.4.7-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250"},
+    {file = "cryptography-3.4.7-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2"},
+    {file = "cryptography-3.4.7-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6"},
+    {file = "cryptography-3.4.7-cp36-abi3-manylinux2014_x86_64.whl", hash = "sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959"},
+    {file = "cryptography-3.4.7-cp36-abi3-win32.whl", hash = "sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d"},
+    {file = "cryptography-3.4.7-cp36-abi3-win_amd64.whl", hash = "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca"},
+    {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873"},
+    {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3"},
+    {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 exceptiongroup = [
     {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
@@ -573,8 +564,8 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 planetmint-cryptoconditions = [
-    {file = "planetmint-cryptoconditions-0.10.0.tar.gz", hash = "sha256:131e8cfc2d64465cb1ff830554a2afd1e779b03b13ab93f8280b7d8fe4382df8"},
-    {file = "planetmint_cryptoconditions-0.10.0-py3-none-any.whl", hash = "sha256:573a70812f321435db547fc0a6bafb2efa6749f199257878a0353964985eec51"},
+    {file = "planetmint_cryptoconditions-1.0.0-py3-none-any.whl", hash = "sha256:d2e2b411635bb7a1934908072bd726d0fd14a9367cddb6f9f9e2720999752aeb"},
+    {file = "planetmint_cryptoconditions-1.0.0.tar.gz", hash = "sha256:1b43156d7391f9bbb0b124aa3acf16fed4287cd7ecdd792da6fa5415358effde"},
 ]
 planetmint-ipld = [
     {file = "planetmint-ipld-0.0.3.tar.gz", hash = "sha256:6effc20e671e01366cb579663809759c6c4ea1ec8e6bcb9278768cd3f7f64243"},
@@ -608,18 +599,7 @@ py-multicodec = [
     {file = "py_multicodec-0.2.1-py2.py3-none-any.whl", hash = "sha256:55b6bb53088a63e56c434cb11b29795e8805652bac43d50a8f2a9bcf5ca84e1f"},
 ]
 pyasn1 = [
-    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
-    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
-    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
-    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
     {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
-    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
-    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
-    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
-    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
-    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
-    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
-    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
     {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
 ]
 pycparser = [
@@ -627,16 +607,24 @@ pycparser = [
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 PyNaCl = [
-    {file = "PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93"},
-    {file = "PyNaCl-1.5.0.tar.gz", hash = "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"},
+    {file = "PyNaCl-1.4.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff"},
+    {file = "PyNaCl-1.4.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:d452a6746f0a7e11121e64625109bc4468fc3100452817001dbe018bb8b08514"},
+    {file = "PyNaCl-1.4.0-cp27-cp27m-win32.whl", hash = "sha256:2fe0fc5a2480361dcaf4e6e7cea00e078fcda07ba45f811b167e3f99e8cff574"},
+    {file = "PyNaCl-1.4.0-cp27-cp27m-win_amd64.whl", hash = "sha256:f8851ab9041756003119368c1e6cd0b9c631f46d686b3904b18c0139f4419f80"},
+    {file = "PyNaCl-1.4.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:7757ae33dae81c300487591c68790dfb5145c7d03324000433d9a2c141f82af7"},
+    {file = "PyNaCl-1.4.0-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:757250ddb3bff1eecd7e41e65f7f833a8405fede0194319f87899690624f2122"},
+    {file = "PyNaCl-1.4.0-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:30f9b96db44e09b3304f9ea95079b1b7316b2b4f3744fe3aaecccd95d547063d"},
+    {file = "PyNaCl-1.4.0-cp35-abi3-win32.whl", hash = "sha256:4e10569f8cbed81cb7526ae137049759d2a8d57726d52c1a000a3ce366779634"},
+    {file = "PyNaCl-1.4.0-cp35-abi3-win_amd64.whl", hash = "sha256:c914f78da4953b33d4685e3cdc7ce63401247a21425c16a39760e282075ac4a6"},
+    {file = "PyNaCl-1.4.0-cp35-cp35m-win32.whl", hash = "sha256:06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4"},
+    {file = "PyNaCl-1.4.0-cp35-cp35m-win_amd64.whl", hash = "sha256:511d269ee845037b95c9781aa702f90ccc36036f95d0f31373a6a79bd8242e25"},
+    {file = "PyNaCl-1.4.0-cp36-cp36m-win32.whl", hash = "sha256:11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4"},
+    {file = "PyNaCl-1.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:cd401ccbc2a249a47a3a1724c2918fcd04be1f7b54eb2a5a71ff915db0ac51c6"},
+    {file = "PyNaCl-1.4.0-cp37-cp37m-win32.whl", hash = "sha256:8122ba5f2a2169ca5da936b2e5a511740ffb73979381b4229d9188f6dcb22f1f"},
+    {file = "PyNaCl-1.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:537a7ccbea22905a0ab36ea58577b39d1fa9b1884869d173b5cf111f006f689f"},
+    {file = "PyNaCl-1.4.0-cp38-cp38-win32.whl", hash = "sha256:9c4a7ea4fb81536c1b1f5cc44d54a296f96ae78c1ebd2311bd0b60be45a48d96"},
+    {file = "PyNaCl-1.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:7c6092102219f59ff29788860ccb021e80fffd953920c4a8653889c029b2d420"},
+    {file = "PyNaCl-1.4.0.tar.gz", hash = "sha256:54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
@@ -769,16 +757,25 @@ varint = [
     {file = "varint-1.0.2.tar.gz", hash = "sha256:a6ecc02377ac5ee9d65a6a8ad45c9ff1dac8ccee19400a5950fb51d594214ca5"},
 ]
 zenroom = [
-    {file = "zenroom-2.1.0.dev1655293214-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:a6de6bdde97df64d8b752e566c2f465b4d84d605e17b8b113f1ad8e2d4e9a7bc"},
-    {file = "zenroom-2.1.0.dev1655293214-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.manylinux_2_24_i686.whl", hash = "sha256:c4b6fc84ccd5d79ca9b172759621240f0d003cc01de9b1e7b3a72b31cb92beda"},
-    {file = "zenroom-2.1.0.dev1655293214-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:99611a415c4e9026bbb3b7f95af10f6a4ccef025d4e4586a068c15a00a429c38"},
-    {file = "zenroom-2.1.0.dev1655293214-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:39b98d4cc9a1119db5af7ca2f9506461c8c421a0ca7de5b08f15f4f968974a66"},
-    {file = "zenroom-2.1.0.dev1655293214-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.manylinux_2_24_i686.whl", hash = "sha256:e4c8d7e593f0201461707fb87f2cc0bdc4cb575768664348582f470a1f4e7157"},
-    {file = "zenroom-2.1.0.dev1655293214-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:d2257326dcdf45c783aeb6a7f0778bff66d785492ec2c774fc69aecad9ee2df4"},
-    {file = "zenroom-2.1.0.dev1655293214-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:6abd2ddc56eb1c81e8388e19f566b92a32d36d90b7664cbd1bc5ac258c1c9d38"},
-    {file = "zenroom-2.1.0.dev1655293214-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.manylinux_2_24_i686.whl", hash = "sha256:c56cf26c5950e2c6337bca56fa95659d49a54e0e1004bb7f34305eb1365aa49e"},
-    {file = "zenroom-2.1.0.dev1655293214-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:42a89f8c3500d60adec22edd2fd019a3f3c3a681c0702e4102e6cada97b51e4d"},
-    {file = "zenroom-2.1.0.dev1655293214-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:066b3d675a3af6896c37f6f1da26ff6462958cbf37cbacc24e6759ea5d910a0f"},
-    {file = "zenroom-2.1.0.dev1655293214-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.manylinux_2_24_i686.whl", hash = "sha256:3a5c54657c7fb5604e97d9f19b04a3615d3834ce9790d596523d80aff3c30a02"},
-    {file = "zenroom-2.1.0.dev1655293214-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41506b789678eebfd255d264c8881da961ead41277f21861f2a5368b85435ea5"},
+    {file = "zenroom-2.4.2-cp310-cp310-linux_armv7l.whl", hash = "sha256:7f4496a9caa70dc38c15162d62d0deff7d23a4e7b2d13c511c25e2c15f472c65"},
+    {file = "zenroom-2.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5c41f41e48360ac86de9a28a751804a1b2bbb8f2013c459ad8c52cf26c654518"},
+    {file = "zenroom-2.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:be7c0f3fac065c27e4678a31347afde4a9623643dfe8bb4855af5c41f58e1d44"},
+    {file = "zenroom-2.4.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.manylinux_2_24_i686.whl", hash = "sha256:da6aa94bf3bb216f5560f91ad38e2317d480b63ab89150109a80584ae51c1084"},
+    {file = "zenroom-2.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:2b558e7a714272412a7ae18c112d70356d36b33e898f63f02c5ad5138e2f0ed6"},
+    {file = "zenroom-2.4.2-cp311-cp311-linux_armv7l.whl", hash = "sha256:875b03b96b7a621fbc9393ef2eeb8cf822bc7f7b1ddc3d8f298123cac49ed9da"},
+    {file = "zenroom-2.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d0ff069c011c0d2cb6a42299b8c1650a5cde48ca9e86a2fcc998477e78351f2b"},
+    {file = "zenroom-2.4.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:5c86e8719329eccebb418ac679fe81b3a19601e3e2b5b93e58d56dbc96732fea"},
+    {file = "zenroom-2.4.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.manylinux_2_24_i686.whl", hash = "sha256:1fa9ba3c81ce653860a1b1756b14356acb442d9ff9c181832d9ef43c361c036f"},
+    {file = "zenroom-2.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:9b5f435247c4ac1df9d3aae0b68a4f4ef87ca76ba7ab352586071536b5f605d3"},
+    {file = "zenroom-2.4.2-cp38-cp38-linux_armv7l.whl", hash = "sha256:1162afb103112b41fbbde0b71e1b3fa9c74c58492749942e36c51e00f50cdd64"},
+    {file = "zenroom-2.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:100d107e4fc64eb42bf1d9689c883d9ddc9da4de5a13b0e4fe0c44f259803998"},
+    {file = "zenroom-2.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:249fe88bee6b688b29ad6c4ff18add36f547a8684a84ff4a921c2fc3e13a75fb"},
+    {file = "zenroom-2.4.2-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.manylinux_2_24_i686.whl", hash = "sha256:ada88fe2e55e5005d554af971ecdefd385b18c7f923b689b0efbd29bb77bdab1"},
+    {file = "zenroom-2.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:7aa582184222efab6bff7715c9a8cb50cebd90cdeb1bc9bff7da07bc3a081031"},
+    {file = "zenroom-2.4.2-cp39-cp39-linux_armv7l.whl", hash = "sha256:a2c0588f2011fae329077e0414c0c60481e1f2f8b3f2ebc65ad1b77242e74b18"},
+    {file = "zenroom-2.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7984a0b81d06e9d1a128c5bb1f996d4cd0f4078853e9a7b249fdac3fb40d92b7"},
+    {file = "zenroom-2.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:4bd57b626288c1c28b5e4e99d8e558c159e7d7bfcd26c7525b9278add668f02a"},
+    {file = "zenroom-2.4.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.manylinux_2_24_i686.whl", hash = "sha256:36682d4b04185bfda7848feef7f11302ae90a12c07529202ae3dc905d5abc84a"},
+    {file = "zenroom-2.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fb41a4e89a1b8d0e012200df641323fad88b8e74efe0c448903900fe56971734"},
+    {file = "zenroom-2.4.2.tar.gz", hash = "sha256:0290f0644976e17bcffd696520997e506c47fb6ef1e425cdd3e06c54aa165815"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "planetmint-transactions"
-version = "0.2.1"
+version = "0.2.2"
 description = "Python implementation of the planetmint transactions spec"
 authors = ["Lorenz Herzberger <lorenzherzberger@gmail.com>"]
 readme = "README.md"
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-planetmint-cryptoconditions = "^0.10.0"
+planetmint-cryptoconditions = "^1.0.0"
 base58 = "^2.1.1"
 planetmint-py-cid = "^0.4.2"
 planetmint-ipld = "^0.0.3"
@@ -22,13 +22,6 @@ PyYAML = "^6.0"
 [tool.poetry.group.test.dependencies]
 hypothesis = "^6.54.6"
 pytest = "^7.1.3"
-
-
-[tool.poetry.group.crypto.dependencies]
-PyNaCl = "^1.5.0"
-pyasn1 = "^0.4.8"
-cryptography = "^38.0.1"
-zenroom = "2.1.0.dev1655293214"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -17,10 +17,10 @@ from transactions.common.transaction import Input
 from transactions.common.exceptions import AmountError
 from transactions.common.transaction import Transaction
 from transactions.common.transaction import TransactionLink
-from cryptoconditions import ThresholdSha256
-from cryptoconditions import Fulfillment
-from cryptoconditions import PreimageSha256
-from cryptoconditions import Ed25519Sha256
+from planetmint_cryptoconditions import ThresholdSha256
+from planetmint_cryptoconditions import Fulfillment
+from planetmint_cryptoconditions import PreimageSha256
+from planetmint_cryptoconditions import Ed25519Sha256
 from pytest import mark, raises
 
 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import random
 
 from base58 import b58decode
-from cryptoconditions import ThresholdSha256, Ed25519Sha256
+from planetmint_cryptoconditions import ThresholdSha256, Ed25519Sha256
 from ipld import marshal, multihash
 from transactions.types.assets.create import Create
 

--- a/transactions/common/crypto.py
+++ b/transactions/common/crypto.py
@@ -6,7 +6,7 @@
 # Separate all crypto code so that we can easily test several implementations
 from collections import namedtuple
 from hashlib import sha3_256
-from cryptoconditions import crypto
+from planetmint_cryptoconditions import crypto
 
 
 CryptoKeypair = namedtuple("CryptoKeypair", ("private_key", "public_key"))

--- a/transactions/common/input.py
+++ b/transactions/common/input.py
@@ -4,8 +4,8 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 from typing import Optional
-from cryptoconditions import Fulfillment
-from cryptoconditions.exceptions import ASN1DecodeError, ASN1EncodeError
+from planetmint_cryptoconditions import Fulfillment
+from planetmint_cryptoconditions.exceptions import ASN1DecodeError, ASN1EncodeError
 
 from transactions.common.exceptions import InvalidSignature
 from .utils import _fulfillment_to_details, _fulfillment_from_details
@@ -19,7 +19,7 @@ class Input(object):
     Wraps around a Crypto-condition Fulfillment.
 
         Attributes:
-            fulfillment (:class:`cryptoconditions.Fulfillment`): A Fulfillment
+            fulfillment (:class:`planetmint_cryptoconditions.Fulfillment`): A Fulfillment
                 to be signed with a private key.
             owners_before (:obj:`list` of :obj:`str`): A list of owners after a
                 Transaction was confirmed.
@@ -32,7 +32,7 @@ class Input(object):
         """Create an instance of an :class:`~.Input`.
 
         Args:
-            fulfillment (:class:`cryptoconditions.Fulfillment`): A
+            fulfillment (:class:`planetmint_cryptoconditions.Fulfillment`): A
                 Fulfillment to be signed with a private key.
             owners_before (:obj:`list` of :obj:`str`): A list of owners
                 after a Transaction was confirmed.

--- a/transactions/common/output.py
+++ b/transactions/common/output.py
@@ -7,8 +7,8 @@ from functools import reduce
 from typing import Union, Optional
 
 import base58
-from cryptoconditions import ThresholdSha256, Ed25519Sha256, ZenroomSha256
-from cryptoconditions import Fulfillment
+from planetmint_cryptoconditions import ThresholdSha256, Ed25519Sha256, ZenroomSha256
+from planetmint_cryptoconditions import Fulfillment
 
 from transactions.common.exceptions import AmountError
 from .utils import _fulfillment_to_details, _fulfillment_from_details
@@ -20,7 +20,7 @@ class Output(object):
     Wraps around a Crypto-condition Condition.
 
         Attributes:
-            fulfillment (:class:`cryptoconditions.Fulfillment`): A Fulfillment
+            fulfillment (:class:`planetmint_cryptoconditions.Fulfillment`): A Fulfillment
                 to extract a Condition from.
             public_keys (:obj:`list` of :obj:`str`, optional): A list of
                 owners before a Transaction was confirmed.
@@ -32,7 +32,7 @@ class Output(object):
         """Create an instance of a :class:`~.Output`.
 
         Args:
-            fulfillment (:class:`cryptoconditions.Fulfillment`): A
+            fulfillment (:class:`planetmint_cryptoconditions.Fulfillment`): A
                 Fulfillment to extract a Condition from.
             public_keys (:obj:`list` of :obj:`str`, optional): A list of
                 owners before a Transaction was confirmed.
@@ -148,13 +148,13 @@ class Output(object):
             :meth:`~.Output.generate`.
 
         Args:
-            initial (:class:`cryptoconditions.ThresholdSha256`):
+            initial (:class:`planetmint_cryptoconditions.ThresholdSha256`):
                 A Condition representing the overall root.
             new_public_keys (:obj:`list` of :obj:`str`|str): A list of new
                 owners or a single new owner.
 
         Returns:
-            :class:`cryptoconditions.ThresholdSha256`:
+            :class:`planetmint_cryptoconditions.ThresholdSha256`:
         """
         try:
             threshold = len(new_public_keys)

--- a/transactions/common/transaction.py
+++ b/transactions/common/transaction.py
@@ -18,8 +18,8 @@ from typing import Optional
 import rapidjson
 
 import base58
-from cryptoconditions import Fulfillment, ThresholdSha256, Ed25519Sha256, ZenroomSha256
-from cryptoconditions.exceptions import ParsingError, ASN1DecodeError, ASN1EncodeError
+from planetmint_cryptoconditions import Fulfillment, ThresholdSha256, Ed25519Sha256, ZenroomSha256
+from planetmint_cryptoconditions.exceptions import ParsingError, ASN1DecodeError, ASN1EncodeError
 from cid import is_cid
 
 from hashlib import sha3_256

--- a/transactions/common/utils.py
+++ b/transactions/common/utils.py
@@ -12,9 +12,9 @@ from typing import Callable
 
 # from planetmint.config import Config
 from transactions.common.exceptions import ValidationError
-from cryptoconditions import ThresholdSha256, Ed25519Sha256, ZenroomSha256, Fulfillment
+from planetmint_cryptoconditions import ThresholdSha256, Ed25519Sha256, ZenroomSha256, Fulfillment
 from transactions.common.exceptions import ThresholdTooDeep
-from cryptoconditions.exceptions import UnsupportedTypeError
+from planetmint_cryptoconditions.exceptions import UnsupportedTypeError
 
 VALID_LANGUAGES = (
     "danish",


### PR DESCRIPTION
the planetmint-cryptoconditions package came with a inconsistent package name. This had to be improved. at the same time, new zenroom version got deployed.

## Checklist

- [X] version number increased
- [X] CHANGELOG.md updated
- [X] unit test added
- [X] documentation updated or added